### PR TITLE
Add concurrency for Verify

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,9 @@ linters-settings:
     min-occurrences: 5
     ignore-tests: true
 
+  gofumpt:
+    extra-rules: true
+
   gosec:
     excludes:
       - G107 # Potential HTTP request made with variable url

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/chainguard-dev/osqtool
 go 1.19
 
 require (
+	github.com/fatih/semgroup v1.2.0
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-multierror v1.1.1
 	k8s.io/klog/v2 v2.80.1
@@ -11,4 +12,5 @@ require (
 require (
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/fatih/semgroup v1.2.0 h1:h/OLXwEM+3NNyAdZEpMiH1OzfplU09i2qXPVThGZvyg=
+github.com/fatih/semgroup v1.2.0/go.mod h1:1KAD4iIYfXjE4U13B48VM4z9QUwV5Tt8O4rS879kgm8=
 github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
@@ -6,5 +8,7 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 k8s.io/klog/v2 v2.80.1 h1:atnLQ121W371wYYFawwYx1aEY2eUfs4l3J72wtgAwV4=
 k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=

--- a/pkg/query/pack.go
+++ b/pkg/query/pack.go
@@ -90,7 +90,7 @@ func LoadPack(path string) (*Pack, error) {
 	return pack, nil
 }
 
-// SaveToDirectories saves a map of queries into a directory.
+// SaveToDirectory saves a map of queries into a directory.
 func SaveToDirectory(mm map[string]*Metadata, destination string) error {
 	for name, m := range mm {
 		s, err := Render(m)

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -117,7 +117,7 @@ func Render(m *Metadata) (string, error) {
 }
 
 // Parse parses query content and returns a Metadata object.
-func Parse(name string, bs []byte) (*Metadata, error) {
+func Parse(name string, bs []byte) (*Metadata, error) { //nolint: funlen // TODO: split into smaller functions
 	// NOTE: The 'name' can be as simple as the file base path
 	m := &Metadata{
 		Name: name,

--- a/pkg/query/verify.go
+++ b/pkg/query/verify.go
@@ -42,14 +42,13 @@ func Verify(m *Metadata) (*VerifyResult, error) {
 		defer stdin.Close()
 		_, err := io.WriteString(stdin, m.Query)
 		if err != nil {
-			klog.Errorf("failed tos end data to osquery: %w", err)
+			klog.Errorf("failed tos end data to osqueryi: %w", err)
 		}
 	}()
 
 	start := time.Now()
 	stdout, err := cmd.Output()
 	elapsed := time.Since(start)
-	klog.Infof("incompatible: %v", incompatible)
 
 	ignoreError := false
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>

As a first time user of this, I couldn't able to run correctly in first run (it requires osqueryi) and on my second attempt, I noticed logs were a bit verbose. And took almost ~3m.

So this PR contains some UX improvements such as the followings:
* Removes annoying empty `incompatible:` log (since it is already printing out in `Partial test for ...: incompatible platform: "linux"` log) - _maybe getting rid of all incompatible platform logs would better UX_
* Introduced `semgroup` package for concurrency
* Round elapsed time (it was too verbose)
* Enable `gofumpt -extra` linter
* Check if `osqueryi` executable in `$PATH` before execute all queries

**Benchmark:**

* Tried on project: https://github.com/chainguard-dev/osquery-defense-kit `(i7-9750H)`

```diff
- time make all  115.71s user 50.61s system 110% cpu 2:43.20 total
+ time make all  120.86s user 54.86s system 316% cpu 52.451 total
```

**Logs:**

```diff
- "..." returned 6 rows within 52.532313381s
+ "..." returned 6 rows within 53s
```