### PR TITLE
Set default --max-duration to 2 seconds

### DIFF
--- a/cmd/osqtool/main.go
+++ b/cmd/osqtool/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	singleQuotesFlag := flag.Bool("single-quotes", false, "Render double quotes as single quotes (may corrupt queries)")
 
-	maxDurationFlag := flag.Duration("max-duration", 4000*time.Millisecond, "Maximum duration (checked during --verify)")
+	maxDurationFlag := flag.Duration("max-duration", 2000*time.Millisecond, "Maximum duration (checked during --verify)")
 	maxTotalRuntimeFlag := flag.Duration("max-total-runtime-per-day", 10*time.Minute, "Maximum total runtime per day")
 	verifyFlag := flag.Bool("verify", false, "Verify the output")
 


### PR DESCRIPTION
It is quite rare that it's acceptable to have a query run longer than this.